### PR TITLE
Resources and Services Test Cases (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ The Sandbox environment is completely separate from the Live site - that include
 Unit tests in this SDK can be run using PHPUnit. The test cases are located in the test/Controllers/ dir.
 
 1. Make sure you've installed the dependencies using composer including the `require-dev` dependencies (you may have already done this with `composer install` or `composer update`).
-1. Run `vendor/bin/phpunit --verbose` from command line to execute the test suite.
+1. Run `vendor/bin/phpunit` from command line to execute the test suite.
+   See https://phpunit.de/manual/current/en/textui.html for info on test output format as well as more command-line options.
 
 ## How to Build
 

--- a/test/Controllers/ResourcesTest.php
+++ b/test/Controllers/ResourcesTest.php
@@ -185,7 +185,7 @@ class ResourcesTest extends TestCase
         // Did it return an array of 3 resources?
         $this->assertCount($perPage, $response->resources);
         foreach($response->resources as $resource) {
-            $this->assertInstanceOf('GonebusyLib\Models\GetResourcesResponse', $response);
+            $this->assertInstanceOf('GonebusyLib\Models\EntitiesResourceResponse', $resource);
         }
     }
 

--- a/test/Controllers/ServicesTest.php
+++ b/test/Controllers/ServicesTest.php
@@ -192,7 +192,7 @@ class ServicesTest extends TestCase
         // Did it return an array of 3 services?
         $this->assertCount($perPage, $response->services);
         foreach($response->services as $service) {
-            $this->assertInstanceOf('GonebusyLib\Models\GetServicesResponse', $response);
+            $this->assertInstanceOf('GonebusyLib\Models\EntitiesServiceResponse', $service);
         }
     }
 


### PR DESCRIPTION
Woops, these test cases also had wrong assertions in their `testGet...` methods.